### PR TITLE
Remove path separator from start of bootloader fix dir name

### DIFF
--- a/tadpole.py
+++ b/tadpole.py
@@ -848,8 +848,8 @@ from tzlion on frogtool. Special thanks also goes to wikkiewikkie & Jason Grieve
     The SF2000 may not boot.  You can always try this fix again in the Firmware options")
                 logging.info("User skipped bootloader")
                 return
-        bootloaderPatchDir = os.path.join(drive,"/UpdateFirmware/")
-        bootloaderPatchPathFile = os.path.join(drive,"/UpdateFirmware/Firmware.upk")
+        bootloaderPatchDir = os.path.join(drive,"UpdateFirmware/")
+        bootloaderPatchPathFile = os.path.join(drive,"UpdateFirmware/Firmware.upk")
         bootloaderChecksum = "eb7a4e9c8aba9f133696d4ea31c1efa50abd85edc1321ce8917becdc98a66927"
         #Let's delete old stuff if it exits incase they tried this before and failed
         if Path(bootloaderPatchDir).is_dir():


### PR DESCRIPTION
Otherwise fails on linux, [because the absolute path segment will make the whole path absolute](https://docs.python.org/3/library/os.path.html#os.path.join:~:text=if%20a%20segment%20is%20an%20absolute%20path%20(which%20on%20windows%20requires%20both%20a%20drive%20and%20a%20root)%2C%20then%20all%20previous%20segments%20are%20ignored%20and%20joining%20continues%20from%20the%20absolute%20path%20segment).
