### PR TITLE
Enable the use of SF2000 menu to display and launch ROMS with MultiCore

### DIFF
--- a/frogtool.py
+++ b/frogtool.py
@@ -221,7 +221,16 @@ def rgb565_convert(src_filename, dest_filename, dest_size=None):
     image.paste(srcimage, None)
 
     if dest_size and image.size != dest_size:
-        # x, y = image.size
+        ratio = dest_size[1] / dest_size[0]
+        if ((image.size[0] * ratio) > image.size[1]):
+            width = image.size[1]/ratio
+            left = int((image.size[0] - width)/2)
+            image = image.crop((left, 0, left + width, image.size[1]))
+        else:
+            height = image.size[0]*ratio
+            top = int((image.size[1] - height)/2)
+            image = image.crop((0, top, image.size[0], top + height))
+
         # new_size=(144, 208)
         # fill_color=(0, 0, 0, 0)
         # size_x = max(dest_size[0], x)

--- a/multicore_functions.py
+++ b/multicore_functions.py
@@ -95,11 +95,25 @@ def makeMulticoreROMList_ARCADEMode(drive):
             print(f"Got to {d}")
             romfolder = os.path.join(drive,"ROMS",d)
             if os.path.exists(romfolder):
+                destination_zfb = "ARCADE"
+                if "snes" in d:
+                    destination_zfb = "SFC"
+                elif "nes" in d:
+                    destination_zfb = "FC"
+                elif "gba" in d:
+                    destination_zfb = "GBA"
+                elif "gbc" in d:
+                    destination_zfb = "GBC"
+                elif "gb" in d:
+                    destination_zfb = "GB"
+                elif "sega" in d:
+                    destination_zfb = "MD"
+
                 for rom in os.listdir(romfolder):
-                    dest_filename = os.path.join(drive, "ARCADE",f"{os.path.splitext(rom)[0]}.zfb")
+                    dest_filename = os.path.join(drive, destination_zfb, f"{os.path.splitext(rom)[0]}.zfb")
                     if(not os.path.exists(dest_filename) and rom not in multicore_exclusionList):
                         romcount += 1
                         # Creates a new file 
                         multicore_rom_string = f"{d};{rom}.gba" 
-                        CreateMulticoreZFB(multicore_rom_string,dest_filename)
+                        CreateMulticoreZFB(multicore_rom_string, dest_filename)
     return romcount

--- a/tadpole_functions.py
+++ b/tadpole_functions.py
@@ -1297,7 +1297,7 @@ def addThumbnail(rom_path, drive, system, new_thumbnail, ovewrite):
                 if not changeZIPThumbnail(rom_path, new_thumbnail, system):
                     return False
             #If its the supported system .z** pass to frogtool
-            elif romExtension == sys_zxx_ext:
+            elif romExtension in frogtool.zxx_ext.values():
                 if ovewrite == True:
                     if not changeZXXThumbnail(rom_path, new_thumbnail):
                         return False


### PR DESCRIPTION
This pull request allows you to display the roms placed in the ROMS/xxx folder in the SF2000's original menus, and launch them with MultiCore.
The ROMS themselves are not modified. A Zfb shortcut is automatically copied to the console folder in the SF2000 menu. It's an evolution of the "Arcade mode" of Tadpole, but in place of putting all the found roms under "arcade" menu, it dispatches ROMS in the right menu.